### PR TITLE
Add namespace to templates of namespace scoped resources

### DIFF
--- a/charts/littlered/templates/deployment.yaml
+++ b/charts/littlered/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "littlered.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "littlered.labels" . | nindent 4 }}
     control-plane: controller-manager

--- a/charts/littlered/templates/metrics-service.yaml
+++ b/charts/littlered/templates/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "littlered.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "littlered.labels" . | nindent 4 }}
     control-plane: controller-manager

--- a/charts/littlered/templates/networkpolicy.yaml
+++ b/charts/littlered/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "littlered.fullname" . }}-allow-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "littlered.labels" . | nindent 4 }}
 spec:

--- a/charts/littlered/templates/poddisruptionbudget.yaml
+++ b/charts/littlered/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "littlered.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "littlered.labels" . | nindent 4 }}
 spec:

--- a/charts/littlered/templates/role.yaml
+++ b/charts/littlered/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "littlered.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "littlered.labels" . | nindent 4 }}
 rules:

--- a/charts/littlered/templates/rolebinding.yaml
+++ b/charts/littlered/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "littlered.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "littlered.labels" . | nindent 4 }}
 roleRef:

--- a/charts/littlered/templates/serviceaccount.yaml
+++ b/charts/littlered/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "littlered.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "littlered.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/littlered/templates/servicemonitor.yaml
+++ b/charts/littlered/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "littlered.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "littlered.labels" . | nindent 4 }}
     control-plane: controller-manager


### PR DESCRIPTION
Kustomize 5.8.0 and later no longer apply namespaces on resources templated via helm. This causes resources generated from templates without `metadata.namespace: {{ .Release.Namespace }}` to have no namespace.

See [fix: Propagate Namespace correctly to Helm #5940](https://github.com/kubernetes-sigs/kustomize/pull/5940) for some more info.

This PR adds `metadata.namespace: {{ .Release.Namespace }}` to all templates of namespace scoped resources.
