### PR TITLE
Consolidate redis_exporter version into single Dependabot-tracked source

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
     directories:
       - /cmd/littlered
       - /cmd/littlered-chaos-client
+      # Pinned default redis_exporter sidecar image (source of truth for the
+      # operator's Go defaults; embedded via //go:embed in api/v1alpha1).
+      - /api/v1alpha1
     schedule:
       interval: weekly
     groups:

--- a/api/v1alpha1/exporter_version_test.go
+++ b/api/v1alpha1/exporter_version_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseExporterImage(t *testing.T) {
+	const (
+		wantPath = "oliver006/redis_exporter"
+		wantTag  = "v1.85.0"
+	)
+	tests := []struct {
+		name       string
+		dockerfile string
+		wantPath   string
+		wantTag    string
+	}{
+		{
+			name:       "registry, path and tag",
+			dockerfile: "FROM docker.io/oliver006/redis_exporter:v1.85.0\n",
+			wantPath:   wantPath,
+			wantTag:    wantTag,
+		},
+		{
+			name:       "no registry host",
+			dockerfile: "FROM oliver006/redis_exporter:v1.85.0\n",
+			wantPath:   wantPath,
+			wantTag:    wantTag,
+		},
+		{
+			name:       "registry with port",
+			dockerfile: "FROM localhost:5000/oliver006/redis_exporter:v1.85.0\n",
+			wantPath:   wantPath,
+			wantTag:    wantTag,
+		},
+		{
+			name:       "comments and blank lines before FROM",
+			dockerfile: "# a comment\n\nFROM docker.io/oliver006/redis_exporter:v1.85.0\n",
+			wantPath:   wantPath,
+			wantTag:    wantTag,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, tag := parseExporterImage(tt.dockerfile)
+			if path != tt.wantPath || tag != tt.wantTag {
+				t.Errorf("parseExporterImage() = (%q, %q), want (%q, %q)", path, tag, tt.wantPath, tt.wantTag)
+			}
+		})
+	}
+}
+
+// TestExporterDefaultsMatchDockerfile ensures the embedded source of truth, the
+// kubebuilder default literal, and the generated CRD stay in lockstep. A
+// Dependabot bump to redis-exporter.Dockerfile that hasn't been mirrored into
+// the kubebuilder marker + `make manifests` will fail here.
+func TestExporterDefaultsMatchDockerfile(t *testing.T) {
+	const crdPath = "../../config/crd/bases/redis.chuck-chuck-chuck.net_littlereds.yaml"
+	crd, err := os.ReadFile(crdPath)
+	if err != nil {
+		t.Fatalf("reading generated CRD: %v", err)
+	}
+	crdStr := string(crd)
+
+	if want := "default: " + DefaultExporterTag + "\n"; !strings.Contains(crdStr, want) {
+		t.Errorf("CRD %s missing exporter tag default %q; run `make manifests` and update the kubebuilder marker on ExporterSpec.Tag", crdPath, DefaultExporterTag)
+	}
+	if want := "default: " + DefaultExporterPath + "\n"; !strings.Contains(crdStr, want) {
+		t.Errorf("CRD %s missing exporter path default %q; run `make manifests`", crdPath, DefaultExporterPath)
+	}
+}

--- a/api/v1alpha1/littlered_defaults.go
+++ b/api/v1alpha1/littlered_defaults.go
@@ -17,7 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	_ "embed"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,8 +38,6 @@ const (
 	DefaultTCPKeepalive    = 300
 	DefaultServiceType     = corev1.ServiceTypeClusterIP
 	DefaultUpdateStrategy  = "RollingUpdate"
-	DefaultExporterPath    = "oliver006/redis_exporter"
-	DefaultExporterTag     = "v1.66.0"
 	DefaultScrapeInterval  = "30s"
 	DefaultScrapeTimeout   = "10s"
 	DefaultSentinelQuorum  = 2
@@ -62,6 +62,55 @@ const (
 	ClusterBusPortOffset       = 10000
 	ClusterBusPort             = RedisPort + ClusterBusPortOffset // 16379
 )
+
+// redis-exporter.Dockerfile is the single source of truth for the default
+// redis_exporter sidecar image. Dependabot's docker ecosystem bumps the FROM
+// line there; the values below are parsed from it at init time so a Dependabot
+// PR is all that's needed to update the default version.
+//
+//go:embed redis-exporter.Dockerfile
+var redisExporterDockerfile string
+
+// DefaultExporterPath and DefaultExporterTag are parsed from
+// redis-exporter.Dockerfile. Keep the kubebuilder default marker on
+// ExporterSpec.Tag in sync (it must be a string literal); TestExporterDefaultsMatchDockerfile guards against drift.
+var DefaultExporterPath, DefaultExporterTag = parseExporterImage(redisExporterDockerfile)
+
+// parseExporterImage extracts the image path (without registry host) and tag
+// from the first FROM line of the embedded Dockerfile. It panics on a malformed
+// reference, surfacing the problem at startup/test time rather than shipping a
+// broken default.
+func parseExporterImage(dockerfile string) (path, tag string) {
+	var ref string
+	for line := range strings.SplitSeq(dockerfile, "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "FROM "); ok {
+			ref = strings.TrimSpace(rest)
+			break
+		}
+	}
+
+	// Split off the tag: the last ':' that comes after the last '/'.
+	if i := strings.LastIndex(ref, ":"); i > strings.LastIndex(ref, "/") {
+		tag = ref[i+1:]
+		ref = ref[:i]
+	}
+
+	// Strip the registry host. The first path segment is a registry if it
+	// contains a '.' or ':' (or is "localhost"); otherwise the registry is
+	// implicit and handled separately via ExporterSpec.Registry inheritance.
+	if i := strings.Index(ref, "/"); i >= 0 {
+		if first := ref[:i]; strings.ContainsAny(first, ".:") || first == "localhost" {
+			ref = ref[i+1:]
+		}
+	}
+	path = ref
+
+	if path == "" || tag == "" {
+		panic(fmt.Sprintf("redis-exporter.Dockerfile: could not parse image path/tag from FROM line %q", ref))
+	}
+	return path, tag
+}
 
 // SetDefaults applies default values to the LittleRed spec
 func (r *LittleRed) SetDefaults() {

--- a/api/v1alpha1/littlered_types.go
+++ b/api/v1alpha1/littlered_types.go
@@ -259,8 +259,10 @@ type ExporterSpec struct {
 	// +optional
 	Path string `json:"path,omitempty"`
 
-	// Tag is the image version tag
-	// +kubebuilder:default="v1.66.0"
+	// Tag is the image version tag.
+	// Keep in sync with redis-exporter.Dockerfile (the source Dependabot bumps);
+	// kubebuilder markers must be string literals so this cannot reference the const.
+	// +kubebuilder:default="v1.85.0"
 	// +optional
 	Tag string `json:"tag,omitempty"`
 
@@ -275,16 +277,16 @@ func (e *ExporterSpec) FullImage(mainRegistry string) string {
 	if registry == "" {
 		registry = mainRegistry
 		if registry == "" {
-			registry = "docker.io"
+			registry = DefaultRegistry
 		}
 	}
 	path := e.Path
 	if path == "" {
-		path = "oliver006/redis_exporter"
+		path = DefaultExporterPath
 	}
 	tag := e.Tag
 	if tag == "" {
-		tag = "v1.66.0"
+		tag = DefaultExporterTag
 	}
 	return fmt.Sprintf("%s/%s:%s", registry, path, tag)
 }

--- a/api/v1alpha1/littlered_types_test.go
+++ b/api/v1alpha1/littlered_types_test.go
@@ -95,13 +95,13 @@ func TestExporterSpec_FullImage(t *testing.T) {
 			name:         "all defaults with empty main registry",
 			spec:         ExporterSpec{},
 			mainRegistry: "",
-			expected:     "docker.io/oliver006/redis_exporter:v1.66.0",
+			expected:     "docker.io/oliver006/redis_exporter:v1.85.0",
 		},
 		{
 			name:         "inherit main registry",
 			spec:         ExporterSpec{},
 			mainRegistry: testRegistryGCR,
-			expected:     "gcr.io/oliver006/redis_exporter:v1.66.0",
+			expected:     "gcr.io/oliver006/redis_exporter:v1.85.0",
 		},
 		{
 			name: "override main registry",
@@ -109,7 +109,7 @@ func TestExporterSpec_FullImage(t *testing.T) {
 				Registry: "quay.io",
 			},
 			mainRegistry: testRegistryGCR,
-			expected:     "quay.io/oliver006/redis_exporter:v1.66.0",
+			expected:     "quay.io/oliver006/redis_exporter:v1.85.0",
 		},
 		{
 			name: "custom path and tag",

--- a/api/v1alpha1/redis-exporter.Dockerfile
+++ b/api/v1alpha1/redis-exporter.Dockerfile
@@ -1,0 +1,9 @@
+# Single source of truth for the default redis_exporter sidecar image.
+#
+# This file is NOT built into an image. It exists so that Dependabot's docker
+# ecosystem can track and bump the redis_exporter version in one place. The
+# reference below is embedded (//go:embed) and parsed at init time to populate
+# DefaultExporterPath / DefaultExporterTag in littlered_defaults.go.
+#
+# Do not add build stages or other FROM lines — the parser reads the first FROM.
+FROM docker.io/oliver006/redis_exporter:v1.85.0

--- a/charts/littlered/crds/redis.chuck-chuck-chuck.net_littlereds.yaml
+++ b/charts/littlered/crds/redis.chuck-chuck-chuck.net_littlereds.yaml
@@ -254,8 +254,11 @@ spec:
                             type: object
                         type: object
                       tag:
-                        default: v1.66.0
-                        description: Tag is the image version tag
+                        default: v1.85.0
+                        description: |-
+                          Tag is the image version tag.
+                          Keep in sync with redis-exporter.Dockerfile (the source Dependabot bumps);
+                          kubebuilder markers must be string literals so this cannot reference the const.
                         type: string
                     type: object
                   serviceMonitor:

--- a/config/crd/bases/redis.chuck-chuck-chuck.net_littlereds.yaml
+++ b/config/crd/bases/redis.chuck-chuck-chuck.net_littlereds.yaml
@@ -254,8 +254,11 @@ spec:
                             type: object
                         type: object
                       tag:
-                        default: v1.66.0
-                        description: Tag is the image version tag
+                        default: v1.85.0
+                        description: |-
+                          Tag is the image version tag.
+                          Keep in sync with redis-exporter.Dockerfile (the source Dependabot bumps);
+                          kubebuilder markers must be string literals so this cannot reference the const.
                         type: string
                     type: object
                   serviceMonitor:

--- a/config/samples/littlered_v1alpha1_littlered_full.yaml
+++ b/config/samples/littlered_v1alpha1_littlered_full.yaml
@@ -30,7 +30,7 @@ spec:
     exporter:
       # Registry inherits from image.registry if empty
       path: oliver006/redis_exporter
-      tag: v1.66.0
+      tag: v1.85.0
     serviceMonitor:
       enabled: false
       interval: "30s"

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -233,7 +233,7 @@ spec:
       # Same pattern as main image: {registry}/{path}:{tag}
       registry: ""              # Empty = inherit from spec.image.registry
       path: oliver006/redis_exporter
-      tag: v1.66.0
+      tag: v1.85.0
       resources:
         requests:
           cpu: "50m"
@@ -254,7 +254,7 @@ spec:
 | `metrics.enabled` | `bool` | No | `true` | Enable redis_exporter sidecar |
 | `metrics.exporter.registry` | `string` | No | (inherit) | Registry; empty = use `spec.image.registry` |
 | `metrics.exporter.path` | `string` | No | `oliver006/redis_exporter` | Image path |
-| `metrics.exporter.tag` | `string` | No | `v1.66.0` | Image tag |
+| `metrics.exporter.tag` | `string` | No | `v1.85.0` | Image tag |
 | `metrics.exporter.resources` | `ResourceRequirements` | No | See above | Exporter container resources |
 | `metrics.serviceMonitor.enabled` | `bool` | No | `false` | Create ServiceMonitor |
 | `metrics.serviceMonitor.namespace` | `string` | No | `""` | ServiceMonitor namespace |
@@ -268,7 +268,7 @@ spec:
 spec:
   image:
     registry: docker.io   # Mirror for all images
-  # Exporter automatically uses: docker.io/oliver006/redis_exporter:v1.66.0
+  # Exporter automatically uses: docker.io/oliver006/redis_exporter:v1.85.0
 ```
 
 ### 2.8 Update Strategy
@@ -595,7 +595,7 @@ spec:
   image:
     registry: docker.io
     # Result: docker.io/library/redis:8.4.2
-    # Exporter: docker.io/oliver006/redis_exporter:v1.66.0
+    # Exporter: docker.io/oliver006/redis_exporter:v1.85.0
 ```
 
 ### 4.5 Standalone with Auth
@@ -685,7 +685,7 @@ spec:
 
   metrics:
     enabled: true
-    # Exporter inherits registry: docker.io/oliver006/redis_exporter:v1.66.0
+    # Exporter inherits registry: docker.io/oliver006/redis_exporter:v1.85.0
     serviceMonitor:
       enabled: true
       labels:

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -1076,7 +1076,7 @@ func TestBuildExporterContainer(t *testing.T) {
 	}
 
 	// Check image
-	expectedImage := "docker.io/oliver006/redis_exporter:v1.66.0"
+	expectedImage := "docker.io/oliver006/redis_exporter:v1.85.0"
 	if container.Image != expectedImage {
 		t.Errorf("Container image = %q, want %q", container.Image, expectedImage)
 	}


### PR DESCRIPTION
The default redis_exporter sidecar image was hardcoded as v1.66.0 across Go constants, a duplicate fallback in ExporterSpec.FullImage, the kubebuilder default marker, and the generated CRD. Collapse these to one source of truth that Dependabot can manage.

- Add api/v1alpha1/redis-exporter.Dockerfile pinning the image; embed it via //go:embed and parse DefaultExporterPath/DefaultExporterTag from it
- Reuse the parsed constants (and DefaultRegistry) in FullImage instead of re-hardcoding the path/tag/registry literals
- Track /api/v1alpha1 in the docker ecosystem in dependabot.yml
- Add TestExporterDefaultsMatchDockerfile to catch drift between the embedded source, the kubebuilder marker, and the generated CRD
- Pin to v1.85.0 so the wiring can be verified by Dependabot bumping to the current v1.86.0

The kubebuilder default marker must remain a string literal (markers can't reference Go consts); the drift guard fails CI if a Dependabot bump isn't mirrored there + `make manifests`.