### PR TITLE
Export metrics for sentinel pods and replica data pods (#6)

### DIFF
--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -312,7 +312,7 @@ func buildStatefulSet(lr *littleredv1alpha1.LittleRed) *appsv1.StatefulSet {
 
 	// Add exporter sidecar if metrics enabled
 	if lr.Spec.Metrics.IsEnabled() {
-		containers = append(containers, buildExporterContainer(lr))
+		containers = append(containers, buildExporterContainer(lr, int32(littleredv1alpha1.RedisPort)))
 	}
 
 	sts := &appsv1.StatefulSet{
@@ -433,12 +433,16 @@ func buildRedisContainer(lr *littleredv1alpha1.LittleRed) corev1.Container {
 	return container
 }
 
-// buildExporterContainer creates the redis_exporter sidecar container
-func buildExporterContainer(lr *littleredv1alpha1.LittleRed) corev1.Container {
+// buildExporterContainer creates a redis_exporter sidecar that scrapes the
+// node listening on targetPort. Redis data nodes use RedisPort; Sentinel nodes
+// use SentinelPort — oliver006/redis_exporter detects a Sentinel endpoint and
+// exposes redis_sentinel_* series. The exporter itself always listens on
+// RedisExporterPort regardless of the target.
+func buildExporterContainer(lr *littleredv1alpha1.LittleRed, targetPort int32) corev1.Container {
 	env := []corev1.EnvVar{
 		{
 			Name:  envRedisAddr,
-			Value: fmt.Sprintf("redis://localhost:%d", littleredv1alpha1.RedisPort),
+			Value: fmt.Sprintf("redis://localhost:%d", targetPort),
 		},
 	}
 
@@ -1028,7 +1032,7 @@ func buildRedisStatefulSetSentinel(lr *littleredv1alpha1.LittleRed) *appsv1.Stat
 
 	// Add exporter sidecar if metrics enabled
 	if lr.Spec.Metrics.IsEnabled() {
-		containers = append(containers, buildExporterContainer(lr))
+		containers = append(containers, buildExporterContainer(lr, int32(littleredv1alpha1.RedisPort)))
 	}
 
 	// MinReadySeconds for Sentinel mode: allow time for Sentinel-managed failover
@@ -1450,6 +1454,13 @@ func buildSentinelStatefulSet(lr *littleredv1alpha1.LittleRed) *appsv1.StatefulS
 
 	replicas := int32(3)
 
+	containers := []corev1.Container{buildSentinelContainer(lr)}
+	// Add exporter sidecar if metrics enabled — points at the Sentinel port so
+	// oliver006/redis_exporter emits redis_sentinel_* series for these pods.
+	if lr.Spec.Metrics.IsEnabled() {
+		containers = append(containers, buildExporterContainer(lr, int32(littleredv1alpha1.SentinelPort)))
+	}
+
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sentinelStatefulSetName(lr),
@@ -1469,7 +1480,7 @@ func buildSentinelStatefulSet(lr *littleredv1alpha1.LittleRed) *appsv1.StatefulS
 				},
 				Spec: corev1.PodSpec{
 					SecurityContext:  lr.Spec.PodTemplate.SecurityContext,
-					Containers:       []corev1.Container{buildSentinelContainer(lr)},
+					Containers:       containers,
 					Volumes:          buildSentinelVolumes(lr),
 					NodeSelector:     lr.Spec.PodTemplate.NodeSelector,
 					Tolerations:      lr.Spec.PodTemplate.Tolerations,
@@ -1628,60 +1639,27 @@ exec redis-sentinel /data/sentinel.conf --sentinel announce-ip ${POD_IP} $AUTH_A
 	return container
 }
 
-// buildMasterService creates the Service that points to the current master
+// buildMasterService creates the Service that points to the current master.
+// It is a role-scoped client entrypoint (selector role=master) and deliberately
+// does not expose metrics or Prometheus scrape annotations: the all-pods
+// replicas headless service is the scrape target, so the master is scraped once.
 func buildMasterService(lr *littleredv1alpha1.LittleRed) *corev1.Service {
 	labels := commonLabels(lr)
 	maps.Copy(labels, lr.Spec.Service.Labels)
 
-	ports := []corev1.ServicePort{
-		{
-			Name:       ComponentRedis,
-			Port:       int32(littleredv1alpha1.RedisPort),
-			TargetPort: intstr.FromString(ComponentRedis),
-			Protocol:   corev1.ProtocolTCP,
-		},
-	}
-
-	if lr.Spec.Metrics.IsEnabled() {
-		ports = append(ports, corev1.ServicePort{
-			Name:       portNameMetrics,
-			Port:       int32(littleredv1alpha1.RedisExporterPort),
-			TargetPort: intstr.FromString(portNameMetrics),
-			Protocol:   corev1.ProtocolTCP,
-		})
-	}
+	annotations := map[string]string{}
+	maps.Copy(annotations, lr.Spec.Service.Annotations)
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        serviceName(lr),
 			Namespace:   lr.Namespace,
 			Labels:      labels,
-			Annotations: serviceAnnotations(lr),
+			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     lr.Spec.Service.Type,
 			Selector: masterSelectorLabels(lr),
-			Ports:    ports,
-		},
-	}
-}
-
-// buildReplicasHeadlessService creates the headless Service for all Redis pods
-func buildReplicasHeadlessService(lr *littleredv1alpha1.LittleRed) *corev1.Service {
-	labels := commonLabels(lr)
-	labels[labelAppComponent] = ComponentRedis
-
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      replicasServiceName(lr),
-			Namespace: lr.Namespace,
-			Labels:    labels,
-		},
-		Spec: corev1.ServiceSpec{
-			Type:                     corev1.ServiceTypeClusterIP,
-			ClusterIP:                serviceClusterNone,
-			Selector:                 redisSelectorLabels(lr),
-			PublishNotReadyAddresses: true,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       ComponentRedis,
@@ -1694,30 +1672,100 @@ func buildReplicasHeadlessService(lr *littleredv1alpha1.LittleRed) *corev1.Servi
 	}
 }
 
+// buildReplicasHeadlessService creates the headless Service for all Redis pods
+func buildReplicasHeadlessService(lr *littleredv1alpha1.LittleRed) *corev1.Service {
+	labels := commonLabels(lr)
+	labels[labelAppComponent] = ComponentRedis
+
+	ports := []corev1.ServicePort{
+		{
+			Name:       ComponentRedis,
+			Port:       int32(littleredv1alpha1.RedisPort),
+			TargetPort: intstr.FromString(ComponentRedis),
+			Protocol:   corev1.ProtocolTCP,
+		},
+	}
+
+	var annotations map[string]string
+	// This headless service selects every Redis data pod (master + replicas),
+	// so it is the scrape target for the whole sentinel data plane — the
+	// role-scoped master service deliberately does not expose metrics to avoid
+	// scraping the master twice.
+	if lr.Spec.Metrics.IsEnabled() {
+		ports = append(ports, corev1.ServicePort{
+			Name:       portNameMetrics,
+			Port:       int32(littleredv1alpha1.RedisExporterPort),
+			TargetPort: intstr.FromString(portNameMetrics),
+			Protocol:   corev1.ProtocolTCP,
+		})
+		annotations = map[string]string{
+			"prometheus.io/scrape": "true",
+			"prometheus.io/port":   fmt.Sprintf("%d", littleredv1alpha1.RedisExporterPort),
+			"prometheus.io/path":   "/metrics",
+		}
+	}
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        replicasServiceName(lr),
+			Namespace:   lr.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                     corev1.ServiceTypeClusterIP,
+			ClusterIP:                serviceClusterNone,
+			Selector:                 redisSelectorLabels(lr),
+			PublishNotReadyAddresses: true,
+			Ports:                    ports,
+		},
+	}
+}
+
 // buildSentinelHeadlessService creates the headless Service for Sentinel pods
 func buildSentinelHeadlessService(lr *littleredv1alpha1.LittleRed) *corev1.Service {
 	labels := commonLabels(lr)
 	labels[labelAppComponent] = ComponentSentinel
 
+	ports := []corev1.ServicePort{
+		{
+			Name:       ComponentSentinel,
+			Port:       int32(littleredv1alpha1.SentinelPort),
+			TargetPort: intstr.FromString(ComponentSentinel),
+			Protocol:   corev1.ProtocolTCP,
+		},
+	}
+
+	var annotations map[string]string
+	// Expose the exporter port so the ServiceMonitor (selects on name+instance)
+	// and prometheus.io annotations pick up the Sentinel pods' metrics.
+	if lr.Spec.Metrics.IsEnabled() {
+		ports = append(ports, corev1.ServicePort{
+			Name:       portNameMetrics,
+			Port:       int32(littleredv1alpha1.RedisExporterPort),
+			TargetPort: intstr.FromString(portNameMetrics),
+			Protocol:   corev1.ProtocolTCP,
+		})
+		annotations = map[string]string{
+			"prometheus.io/scrape": "true",
+			"prometheus.io/port":   fmt.Sprintf("%d", littleredv1alpha1.RedisExporterPort),
+			"prometheus.io/path":   "/metrics",
+		}
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sentinelServiceName(lr),
-			Namespace: lr.Namespace,
-			Labels:    labels,
+			Name:        sentinelServiceName(lr),
+			Namespace:   lr.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                     corev1.ServiceTypeClusterIP,
 			ClusterIP:                serviceClusterNone,
 			Selector:                 sentinelSelectorLabels(lr),
 			PublishNotReadyAddresses: true,
-			Ports: []corev1.ServicePort{
-				{
-					Name:       ComponentSentinel,
-					Port:       int32(littleredv1alpha1.SentinelPort),
-					TargetPort: intstr.FromString(ComponentSentinel),
-					Protocol:   corev1.ProtocolTCP,
-				},
-			},
+			Ports:                    ports,
 		},
 	}
 }
@@ -1850,7 +1898,7 @@ func buildClusterStatefulSet(lr *littleredv1alpha1.LittleRed) *appsv1.StatefulSe
 
 	// Add exporter sidecar if metrics enabled
 	if lr.Spec.Metrics.IsEnabled() {
-		containers = append(containers, buildExporterContainer(lr))
+		containers = append(containers, buildExporterContainer(lr, int32(littleredv1alpha1.RedisPort)))
 	}
 
 	// MinReadySeconds ensures pods are stable before next pod is restarted during rolling updates.

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -99,20 +99,22 @@ func clusterPodDisruptionBudgetName(lr *littleredv1alpha1.LittleRed) string {
 
 // Label keys
 const (
-	ComponentRedis      = "redis"
-	ComponentSentinel   = "sentinel"
-	ComponentCluster    = "cluster"
-	LabelRole           = "redis.chuck-chuck-chuck.net/role"
-	ModeStandalone      = "standalone"
-	ModeSentinel        = "sentinel"
-	ModeCluster         = "cluster"
-	RoleMaster          = "master"
-	RoleReplica         = "replica"
-	RoleOrphan          = "orphan"
-	RoleUndefined       = "undefined"
-	annotationValueTrue = "true"
-	tlsInsecureFlags    = "--tls --insecure"
-	portNameMetrics     = "metrics"
+	ComponentRedis        = "redis"
+	ComponentSentinel     = "sentinel"
+	ComponentCluster      = "cluster"
+	LabelRole             = "redis.chuck-chuck-chuck.net/role"
+	ModeStandalone        = "standalone"
+	ModeSentinel          = "sentinel"
+	ModeCluster           = "cluster"
+	RoleMaster            = "master"
+	RoleReplica           = "replica"
+	RoleOrphan            = "orphan"
+	RoleUndefined         = "undefined"
+	annotationValueTrue   = "true"
+	tlsInsecureFlags      = "--tls --insecure"
+	portNameMetrics       = "metrics"
+	containerNameExporter = "exporter"
+	pathMetrics           = "/metrics"
 
 	labelAppName      = "app.kubernetes.io/name"
 	labelAppInstance  = "app.kubernetes.io/instance"
@@ -465,12 +467,12 @@ func buildExporterContainer(lr *littleredv1alpha1.LittleRed, targetPort int32) c
 	if lr.Spec.TLS.Enabled {
 		env[0].Value = fmt.Sprintf("rediss://localhost:%d", littleredv1alpha1.RedisPort)
 		env = append(env,
-			corev1.EnvVar{Name: "REDIS_EXPORTER_SKIP_TLS_VERIFICATION", Value: "true"},
+			corev1.EnvVar{Name: "REDIS_EXPORTER_SKIP_TLS_VERIFICATION", Value: annotationValueTrue},
 		)
 	}
 
 	container := corev1.Container{
-		Name:            "exporter",
+		Name:            containerNameExporter,
 		Image:           lr.Spec.Metrics.Exporter.FullImage(lr.Spec.Image.Registry),
 		ImagePullPolicy: lr.Spec.Image.PullPolicy,
 		Env:             env,
@@ -751,9 +753,9 @@ func serviceAnnotations(lr *littleredv1alpha1.LittleRed) map[string]string {
 	annotations := map[string]string{}
 	maps.Copy(annotations, lr.Spec.Service.Annotations)
 	if lr.Spec.Metrics.IsEnabled() {
-		annotations["prometheus.io/scrape"] = "true"
+		annotations["prometheus.io/scrape"] = annotationValueTrue
 		annotations["prometheus.io/port"] = fmt.Sprintf("%d", littleredv1alpha1.RedisExporterPort)
-		annotations["prometheus.io/path"] = "/metrics"
+		annotations["prometheus.io/path"] = pathMetrics
 	}
 	return annotations
 }
@@ -1699,9 +1701,9 @@ func buildReplicasHeadlessService(lr *littleredv1alpha1.LittleRed) *corev1.Servi
 			Protocol:   corev1.ProtocolTCP,
 		})
 		annotations = map[string]string{
-			"prometheus.io/scrape": "true",
+			"prometheus.io/scrape": annotationValueTrue,
 			"prometheus.io/port":   fmt.Sprintf("%d", littleredv1alpha1.RedisExporterPort),
-			"prometheus.io/path":   "/metrics",
+			"prometheus.io/path":   pathMetrics,
 		}
 	}
 
@@ -1747,9 +1749,9 @@ func buildSentinelHeadlessService(lr *littleredv1alpha1.LittleRed) *corev1.Servi
 			Protocol:   corev1.ProtocolTCP,
 		})
 		annotations = map[string]string{
-			"prometheus.io/scrape": "true",
+			"prometheus.io/scrape": annotationValueTrue,
 			"prometheus.io/port":   fmt.Sprintf("%d", littleredv1alpha1.RedisExporterPort),
-			"prometheus.io/path":   "/metrics",
+			"prometheus.io/path":   pathMetrics,
 		}
 	}
 

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -922,10 +922,10 @@ func TestBuildSentinelStatefulSet(t *testing.T) {
 		t.Errorf("StatefulSet serviceName = %q, want %q", sts.Spec.ServiceName, testSentinelName)
 	}
 
-	// Check container
+	// Check containers: sentinel + exporter sidecar (metrics default-on)
 	containers := sts.Spec.Template.Spec.Containers
-	if len(containers) != 1 {
-		t.Errorf("StatefulSet has %d containers, want 1", len(containers))
+	if len(containers) != 2 {
+		t.Errorf("StatefulSet has %d containers, want 2 (sentinel + exporter)", len(containers))
 	}
 	if containers[0].Name != ComponentSentinel {
 		t.Errorf("Container name = %q, want sentinel", containers[0].Name)
@@ -942,6 +942,21 @@ func TestBuildSentinelStatefulSet(t *testing.T) {
 		t.Error("Sentinel container missing port 26379")
 	}
 
+	// Check exporter sidecar scrapes the Sentinel port, not the Redis port
+	exporter := containers[1]
+	if exporter.Name != "exporter" {
+		t.Fatalf("second container name = %q, want exporter", exporter.Name)
+	}
+	var exporterAddr string
+	for _, env := range exporter.Env {
+		if env.Name == envRedisAddr {
+			exporterAddr = env.Value
+		}
+	}
+	if exporterAddr != "redis://localhost:26379" {
+		t.Errorf("exporter REDIS_ADDR = %q, want redis://localhost:26379", exporterAddr)
+	}
+
 	// Check config hash annotation is present
 	annotations := sts.Spec.Template.Annotations
 	if annotations == nil {
@@ -949,6 +964,34 @@ func TestBuildSentinelStatefulSet(t *testing.T) {
 	}
 	if _, ok := annotations[AnnotationConfigHash]; !ok {
 		t.Error("StatefulSet pod template missing config hash annotation")
+	}
+}
+
+func TestBuildSentinelStatefulSetWithoutMetrics(t *testing.T) {
+	lr := newTestLittleRed(testLRName, testNamespace)
+	lr.Spec.Mode = ModeSentinel
+	enabled := false
+	lr.Spec.Metrics.Enabled = &enabled
+	sts := buildSentinelStatefulSet(lr)
+
+	// Should only have the sentinel container, no exporter sidecar
+	containers := sts.Spec.Template.Spec.Containers
+	if len(containers) != 1 {
+		t.Errorf("StatefulSet has %d containers, want 1 (sentinel only)", len(containers))
+	}
+	if containers[0].Name != ComponentSentinel {
+		t.Errorf("Container name = %q, want sentinel", containers[0].Name)
+	}
+
+	// Sentinel headless service should not expose a metrics port
+	svc := buildSentinelHeadlessService(lr)
+	for _, p := range svc.Spec.Ports {
+		if p.Name == portNameMetrics {
+			t.Error("Sentinel service should not have metrics port when metrics disabled")
+		}
+	}
+	if svc.Annotations["prometheus.io/scrape"] != "" {
+		t.Error("Sentinel service should not have scrape annotation when metrics disabled")
 	}
 }
 
@@ -965,6 +1008,18 @@ func TestBuildMasterService(t *testing.T) {
 	// Check selector includes role=master
 	if svc.Spec.Selector[LabelRole] != RoleMaster {
 		t.Error("Master service selector should have role=master")
+	}
+
+	// Master service is role-scoped and must NOT expose metrics or scrape
+	// annotations — the all-pods replicas headless service is the scrape target,
+	// so the master is not scraped twice.
+	for _, p := range svc.Spec.Ports {
+		if p.Name == portNameMetrics {
+			t.Error("Master service should not expose metrics port (avoid double-scrape of master)")
+		}
+	}
+	if svc.Annotations["prometheus.io/scrape"] != "" {
+		t.Error("Master service should not carry prometheus scrape annotation")
 	}
 }
 
@@ -987,6 +1042,38 @@ func TestBuildReplicasHeadlessService(t *testing.T) {
 	if !svc.Spec.PublishNotReadyAddresses {
 		t.Error("Headless service should publishNotReadyAddresses")
 	}
+
+	// Selects all redis data pods, so it carries the metrics port + scrape
+	// annotations (metrics default-on) — this is the data-plane scrape target.
+	var hasMetricsPort bool
+	for _, p := range svc.Spec.Ports {
+		if p.Name == portNameMetrics && p.Port == 9121 {
+			hasMetricsPort = true
+		}
+	}
+	if !hasMetricsPort {
+		t.Error("Replicas headless service should expose metrics port 9121 when metrics enabled")
+	}
+	if svc.Annotations["prometheus.io/scrape"] != "true" {
+		t.Error("Replicas headless service missing prometheus.io/scrape annotation")
+	}
+}
+
+func TestBuildReplicasHeadlessServiceWithoutMetrics(t *testing.T) {
+	lr := newTestLittleRed(testLRName, testNamespace)
+	lr.Spec.Mode = ModeSentinel
+	enabled := false
+	lr.Spec.Metrics.Enabled = &enabled
+	svc := buildReplicasHeadlessService(lr)
+
+	for _, p := range svc.Spec.Ports {
+		if p.Name == portNameMetrics {
+			t.Error("Replicas headless service should not expose metrics port when metrics disabled")
+		}
+	}
+	if svc.Annotations["prometheus.io/scrape"] != "" {
+		t.Error("Replicas headless service should not carry scrape annotation when metrics disabled")
+	}
 }
 
 func TestBuildSentinelHeadlessService(t *testing.T) {
@@ -1004,9 +1091,26 @@ func TestBuildSentinelHeadlessService(t *testing.T) {
 		t.Errorf("Service ClusterIP = %q, want None", svc.Spec.ClusterIP)
 	}
 
-	// Check port
-	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 26379 {
+	// Check ports: sentinel + metrics (metrics default-on)
+	var hasSentinelPort, hasMetricsPort bool
+	for _, p := range svc.Spec.Ports {
+		switch {
+		case p.Name == ComponentSentinel && p.Port == 26379:
+			hasSentinelPort = true
+		case p.Name == portNameMetrics && p.Port == 9121:
+			hasMetricsPort = true
+		}
+	}
+	if !hasSentinelPort {
 		t.Error("Sentinel service should have port 26379")
+	}
+	if !hasMetricsPort {
+		t.Error("Sentinel service should expose metrics port 9121 when metrics enabled")
+	}
+
+	// Check Prometheus scrape annotations are present
+	if svc.Annotations["prometheus.io/scrape"] != "true" {
+		t.Error("Sentinel service missing prometheus.io/scrape annotation")
 	}
 }
 
@@ -1068,7 +1172,7 @@ func TestBuildServiceMonitorWithCustomLabels(t *testing.T) {
 
 func TestBuildExporterContainer(t *testing.T) {
 	lr := newTestLittleRed(testLRName, testNamespace)
-	container := buildExporterContainer(lr)
+	container := buildExporterContainer(lr, int32(littleredv1alpha1.RedisPort))
 
 	// Check name
 	if container.Name != "exporter" {
@@ -1110,7 +1214,7 @@ func TestBuildExporterContainer(t *testing.T) {
 func TestBuildExporterContainerWithTLS(t *testing.T) {
 	lr := newTestLittleRed(testLRName, testNamespace)
 	lr.Spec.TLS.Enabled = true
-	container := buildExporterContainer(lr)
+	container := buildExporterContainer(lr, int32(littleredv1alpha1.RedisPort))
 
 	// Check REDIS_ADDR uses rediss://
 	var hasRedisAddr bool

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -944,7 +944,7 @@ func TestBuildSentinelStatefulSet(t *testing.T) {
 
 	// Check exporter sidecar scrapes the Sentinel port, not the Redis port
 	exporter := containers[1]
-	if exporter.Name != "exporter" {
+	if exporter.Name != containerNameExporter {
 		t.Fatalf("second container name = %q, want exporter", exporter.Name)
 	}
 	var exporterAddr string
@@ -1054,7 +1054,7 @@ func TestBuildReplicasHeadlessService(t *testing.T) {
 	if !hasMetricsPort {
 		t.Error("Replicas headless service should expose metrics port 9121 when metrics enabled")
 	}
-	if svc.Annotations["prometheus.io/scrape"] != "true" {
+	if svc.Annotations["prometheus.io/scrape"] != annotationValueTrue {
 		t.Error("Replicas headless service missing prometheus.io/scrape annotation")
 	}
 }
@@ -1109,7 +1109,7 @@ func TestBuildSentinelHeadlessService(t *testing.T) {
 	}
 
 	// Check Prometheus scrape annotations are present
-	if svc.Annotations["prometheus.io/scrape"] != "true" {
+	if svc.Annotations["prometheus.io/scrape"] != annotationValueTrue {
 		t.Error("Sentinel service missing prometheus.io/scrape annotation")
 	}
 }
@@ -1175,7 +1175,7 @@ func TestBuildExporterContainer(t *testing.T) {
 	container := buildExporterContainer(lr, int32(littleredv1alpha1.RedisPort))
 
 	// Check name
-	if container.Name != "exporter" {
+	if container.Name != containerNameExporter {
 		t.Errorf("Container name = %q, want exporter", container.Name)
 	}
 


### PR DESCRIPTION
Closes #6.

## Problem

The `redis_exporter` sidecar was wired into the standalone, sentinel-data, and cluster StatefulSets, but **missing from the sentinel pods themselves** — so the three sentinel pods emitted no metrics (the gap Michael reported).

While closing that, an adjacent gap surfaced: in sentinel mode only the **current master** was ever scraped (the metrics port lived on the role-scoped master service). Replica data-pod exporters ran but nothing collected them — no replica lag/memory/connection metrics at all.

## Changes

- **Parameterize `buildExporterContainer` by target port.** The sentinel pod gets a sidecar pointed at `26379`, so oliver006/redis_exporter detects a Sentinel endpoint and emits `redis_sentinel_*` series. (`--requirepass` means the existing `REDIS_PASSWORD` authenticates as the default user — no ACL setup needed.)
- **Expose metrics on the sentinel headless service** (named `metrics` port + `prometheus.io/*` annotations) when metrics are enabled.
- **Move the metrics port from the master service to the replicas headless service.** The replicas headless service selects *all* redis data pods, so master and replicas are each scraped **once** — matching cluster mode's all-pods scrape target and avoiding double-scraping the master.

The existing `ServiceMonitor` (selects on name+instance) picks up both services automatically once they carry a named `metrics` port — no ServiceMonitor change needed.

## Why "move" rather than "add to both"

| | Before | This PR (move) | Add to both |
|---|---|---|---|
| Master scraped | once | once | **twice** (dup series) |
| Replicas scraped | **never** | once | once |
| `sum()` over the job | correct | correct | **double-counts master** |

Keeping metrics on both services would double-count the master in aggregations. The master's metrics remain fully available after the move — identify it via the `role` label / the exporter's `redis_instance_info{role="master"}`.

## Behavior change (pre-v1.0)

In **sentinel mode**, the master service no longer advertises a `metrics` port or `prometheus.io/scrape` annotations. Nothing in-repo (docs/dashboards/e2e) depends on this; the documented scrape path is the ServiceMonitor, which adapts automatically. Standalone and cluster modes are unchanged.

## Tests

Updated `TestBuildSentinelStatefulSet`, `TestBuildSentinelHeadlessService`, `TestBuildReplicasHeadlessService`, `TestBuildMasterService`; added `TestBuildSentinelStatefulSetWithoutMetrics` and `TestBuildReplicasHeadlessServiceWithoutMetrics` for the disabled path. `go build`, `go vet`, and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)