### PR TITLE
Reject mode-mismatched spec.cluster / spec.sentinel (#61)

### DIFF
--- a/api/v1alpha1/littlered_types.go
+++ b/api/v1alpha1/littlered_types.go
@@ -27,6 +27,8 @@ import (
 )
 
 // LittleRedSpec defines the desired state of LittleRed
+// +kubebuilder:validation:XValidation:rule="self.mode == 'cluster' || !has(self.cluster)",message="spec.cluster may only be set when spec.mode is 'cluster'"
+// +kubebuilder:validation:XValidation:rule="self.mode == 'sentinel' || !has(self.sentinel)",message="spec.sentinel may only be set when spec.mode is 'sentinel'"
 type LittleRedSpec struct {
 	// Mode is the deployment mode: standalone, sentinel, or cluster
 	// +kubebuilder:validation:Enum=standalone;sentinel;cluster

--- a/charts/littlered/crds/redis.chuck-chuck-chuck.net_littlereds.yaml
+++ b/charts/littlered/crds/redis.chuck-chuck-chuck.net_littlereds.yaml
@@ -1928,6 +1928,11 @@ spec:
                     type: string
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: spec.cluster may only be set when spec.mode is 'cluster'
+              rule: self.mode == 'cluster' || !has(self.cluster)
+            - message: spec.sentinel may only be set when spec.mode is 'sentinel'
+              rule: self.mode == 'sentinel' || !has(self.sentinel)
           status:
             description: LittleRedStatus defines the observed state of LittleRed
             properties:

--- a/config/crd/bases/redis.chuck-chuck-chuck.net_littlereds.yaml
+++ b/config/crd/bases/redis.chuck-chuck-chuck.net_littlereds.yaml
@@ -1928,6 +1928,11 @@ spec:
                     type: string
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: spec.cluster may only be set when spec.mode is 'cluster'
+              rule: self.mode == 'cluster' || !has(self.cluster)
+            - message: spec.sentinel may only be set when spec.mode is 'sentinel'
+              rule: self.mode == 'sentinel' || !has(self.sentinel)
           status:
             description: LittleRedStatus defines the observed state of LittleRed
             properties:

--- a/internal/controller/littlered_controller_test.go
+++ b/internal/controller/littlered_controller_test.go
@@ -30,6 +30,8 @@ import (
 	littleredv1alpha1 "github.com/littlered-operator/littlered-operator/api/v1alpha1"
 )
 
+const testNamespaceDefault = "default"
+
 var _ = Describe("LittleRed Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
@@ -38,7 +40,7 @@ var _ = Describe("LittleRed Controller", func() {
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: testNamespaceDefault, // TODO(user):Modify as needed
 		}
 		littlered := &littleredv1alpha1.LittleRed{}
 
@@ -49,7 +51,7 @@ var _ = Describe("LittleRed Controller", func() {
 				resource := &littleredv1alpha1.LittleRed{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: testNamespaceDefault,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}
@@ -89,13 +91,13 @@ var _ = Describe("LittleRed Controller", func() {
 
 		newLR := func(name string) *littleredv1alpha1.LittleRed {
 			return &littleredv1alpha1.LittleRed{
-				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespaceDefault},
 			}
 		}
 
 		It("rejects spec.cluster when mode is not cluster", func() {
 			lr := newLR("mismatch-cluster")
-			lr.Spec.Mode = "standalone"
+			lr.Spec.Mode = ModeStandalone
 			lr.Spec.Cluster = &littleredv1alpha1.ClusterSpec{Shards: 3}
 
 			err := k8sClient.Create(ctx, lr)
@@ -105,7 +107,7 @@ var _ = Describe("LittleRed Controller", func() {
 
 		It("rejects spec.sentinel when mode is not sentinel", func() {
 			lr := newLR("mismatch-sentinel")
-			lr.Spec.Mode = "standalone"
+			lr.Spec.Mode = ModeStandalone
 			lr.Spec.Sentinel = &littleredv1alpha1.SentinelSpec{}
 
 			err := k8sClient.Create(ctx, lr)
@@ -115,7 +117,7 @@ var _ = Describe("LittleRed Controller", func() {
 
 		It("allows the matching mode-specific block", func() {
 			lr := newLR("match-cluster")
-			lr.Spec.Mode = "cluster"
+			lr.Spec.Mode = ModeCluster
 			lr.Spec.Cluster = &littleredv1alpha1.ClusterSpec{Shards: 3}
 
 			Expect(k8sClient.Create(ctx, lr)).To(Succeed())
@@ -124,7 +126,7 @@ var _ = Describe("LittleRed Controller", func() {
 
 		It("allows a CR with no mode-specific block", func() {
 			lr := newLR("no-block")
-			lr.Spec.Mode = "standalone"
+			lr.Spec.Mode = ModeStandalone
 
 			Expect(k8sClient.Create(ctx, lr)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, lr)).To(Succeed())

--- a/internal/controller/littlered_controller_test.go
+++ b/internal/controller/littlered_controller_test.go
@@ -81,4 +81,53 @@ var _ = Describe("LittleRed Controller", func() {
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})
 	})
+
+	// Mode-mismatch validation is enforced by CEL x-kubernetes-validations rules
+	// on the CRD, so it is rejected by the apiserver at admission time.
+	Context("When validating mode-specific spec blocks (issue #61)", func() {
+		ctx := context.Background()
+
+		newLR := func(name string) *littleredv1alpha1.LittleRed {
+			return &littleredv1alpha1.LittleRed{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			}
+		}
+
+		It("rejects spec.cluster when mode is not cluster", func() {
+			lr := newLR("mismatch-cluster")
+			lr.Spec.Mode = "standalone"
+			lr.Spec.Cluster = &littleredv1alpha1.ClusterSpec{Shards: 3}
+
+			err := k8sClient.Create(ctx, lr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.cluster may only be set when spec.mode is 'cluster'"))
+		})
+
+		It("rejects spec.sentinel when mode is not sentinel", func() {
+			lr := newLR("mismatch-sentinel")
+			lr.Spec.Mode = "standalone"
+			lr.Spec.Sentinel = &littleredv1alpha1.SentinelSpec{}
+
+			err := k8sClient.Create(ctx, lr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.sentinel may only be set when spec.mode is 'sentinel'"))
+		})
+
+		It("allows the matching mode-specific block", func() {
+			lr := newLR("match-cluster")
+			lr.Spec.Mode = "cluster"
+			lr.Spec.Cluster = &littleredv1alpha1.ClusterSpec{Shards: 3}
+
+			Expect(k8sClient.Create(ctx, lr)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, lr)).To(Succeed())
+		})
+
+		It("allows a CR with no mode-specific block", func() {
+			lr := newLR("no-block")
+			lr.Spec.Mode = "standalone"
+
+			Expect(k8sClient.Create(ctx, lr)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, lr)).To(Succeed())
+		})
+	})
 })


### PR DESCRIPTION
Closes #61.

## Problem

A CR could carry `spec.cluster` or `spec.sentinel` regardless of `spec.mode`, and the mismatched block was **silently ignored** — no rejection, no warning. e.g. `mode: standalone` with a `spec.cluster` block applied cleanly and did nothing.

## Fix

Two CEL `x-kubernetes-validations` rules on `LittleRedSpec`, so the apiserver rejects the mismatch at admission time (`kubectl apply` fails immediately — no webhook, no controller round-trip):

- `spec.cluster may only be set when spec.mode is 'cluster'`
- `spec.sentinel may only be set when spec.mode is 'sentinel'`

CEL evaluates the raw submitted object *before* the controller's `SetDefaults` runs (which auto-creates `spec.Sentinel` in sentinel mode), so the auto-created block never trips the rule. `spec.mode`'s apiserver default (`standalone`) is applied before CEL, so the rules see a populated mode.

Regenerated the CRD (`config/crd/bases/...`) and synced the Helm chart copy.

## Tests

Added envtest specs (real apiserver enforces CEL) covering:
- reject `spec.cluster` when mode ≠ cluster (asserts the message)
- reject `spec.sentinel` when mode ≠ sentinel (asserts the message)
- allow the matching mode-specific block
- allow a CR with no mode-specific block

`go build`, `go vet`, and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)