### PR TITLE
build: bump local golangci-lint to v2.12.2 to match CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.12.2
 GO_LICENSES_VERSION ?= v1.6.0
 
 .PHONY: controller-gen


### PR DESCRIPTION
## Summary
The lint CI workflow pins `golangci-lint` **v2.12.2** (`.github/workflows/lint.yml`), but the Makefile installed **v2.7.2** locally. This drift let `goconst` issues pass `make lint` locally while failing CI (as happened on #88 and #89).

This bumps `GOLANGCI_LINT_VERSION` in the Makefile to v2.12.2 so local linting matches CI exactly.

## Test plan
- `make lint` reinstalls v2.12.2 and reports `0 issues` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)