### PR TITLE
docs: rename LLM_STARTUP.md to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ test/e2e/                   # End-to-end tests (requires Kind)
 3. **Auto-Generated Files**: Do not manually edit files marked `DO NOT EDIT` (e.g., `zz_generated.*`, `config/crd/bases/*`). Run `make manifests generate` instead.
 4. **Owner References**: Use `SetControllerReference` so K8s garbage collects child resources when the `LittleRed` CR is deleted.
 5. **Testing**: Add unit tests in `internal/controller/` and E2E tests in `test/e2e/` for any new feature or bug fix.
-6. **Documentation Maintenance**: After any non-trivial change to the data model (API/Status), operator logic, or architectural decisions, you **MUST** update all relevant documentation files (e.g., `docs/API_SPEC.md`, `docs/ARCHITECTURE.md`, `LLM_STARTUP.md`, etc.).
+6. **Documentation Maintenance**: After any non-trivial change to the data model (API/Status), operator logic, or architectural decisions, you **MUST** update all relevant documentation files (e.g., `docs/API_SPEC.md`, `docs/ARCHITECTURE.md`, `CLAUDE.md`, etc.).
 7. **Licensing**: The project is Apache-2.0 (`LICENSE`). Every Go source file carries the standard header `Copyright <year> The littlered Authors.` from `hack/boilerplate.go.txt` — do not attribute copyright to any individual or company. Third-party attributions live in `NOTICE`; the full dependency-license inventory is generated (`make licenses`) into `THIRD_PARTY_LICENSES`. Regenerate it whenever dependencies change. See `AUTHORS` for maintainers.
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -630,7 +630,7 @@ littlered/
 │       └── 004-tls-insecure-skip-verify.md
 ├── Makefile
 ├── go.mod
-└── LLM_STARTUP.md
+└── CLAUDE.md
 ```
 
 ---
@@ -666,4 +666,4 @@ littlered/
 - [ADR-003: Low-Interference Sentinel Reconciliation](adr/003-low-interference-sentinel-reconciliation.md)
 - [ADR-004: TLS InsecureSkipVerify](adr/004-tls-insecure-skip-verify.md)
 - [Reconciliation Algorithm Changelog](RECONCILIATION_ALGORITHM_CHANGELOG.md)
-- [LLM_STARTUP.md](../LLM_STARTUP.md) — condensed project overview for LLM onboarding
+- [CLAUDE.md](../CLAUDE.md) — condensed project overview for LLM onboarding

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -221,4 +221,4 @@ See [SCOPE.md](SCOPE.md) for the full in/out of scope breakdown.
 - [Scope Definition](SCOPE.md)
 - [Reconciliation Algorithm Changelog](RECONCILIATION_ALGORITHM_CHANGELOG.md)
 - Architecture Decision Records: `docs/adr/`
-- [LLM Startup Guide](../LLM_STARTUP.md)
+- [LLM Startup Guide](../CLAUDE.md)

--- a/docs/adr/001-strict-ip-identity.md
+++ b/docs/adr/001-strict-ip-identity.md
@@ -128,5 +128,5 @@ If LittleRed eventually supports PersistentVolumes (PVCs), this decision **must 
 - **Logic Pivot**: The Operator will need an internal `IdentityMode` switch (derived from the `PersistenceEnabled` state) to toggle between IP-based and Hostname-based logic.
 
 ## References
-- `LLM_STARTUP.md` (Architectural Pillars)
+- `CLAUDE.md` (Architectural Pillars)
 - `docs/ARCHITECTURE.md` (Safe Bootstrap)

--- a/docs/adr/003-low-interference-sentinel-reconciliation.md
+++ b/docs/adr/003-low-interference-sentinel-reconciliation.md
@@ -4,7 +4,7 @@
 Accepted
 
 ## Context
-Starting with commit 89ea364, the sentinel reconciliation loop (`reconcileSentinelCluster`) was progressively expanded to actively heal the cluster by issuing SLAVEOF and SENTINEL MONITOR commands to individual Redis and Sentinel nodes. While well-intentioned, this violated the "Minimal Interference" principle (Section 2.5 of LLM_STARTUP.md) and introduced regressions where the operator fought Sentinel's built-in failover mechanisms.
+Starting with commit 89ea364, the sentinel reconciliation loop (`reconcileSentinelCluster`) was progressively expanded to actively heal the cluster by issuing SLAVEOF and SENTINEL MONITOR commands to individual Redis and Sentinel nodes. While well-intentioned, this violated the "Minimal Interference" principle (Section 2.5 of CLAUDE.md) and introduced regressions where the operator fought Sentinel's built-in failover mechanisms.
 
 Specific problems observed:
 - **SLAVEOF interference**: The operator issued `SLAVEOF` commands to nodes it believed were misconfigured, sometimes racing with Sentinel's own reconfiguration during failovers.


### PR DESCRIPTION
## Summary
Renames the project onboarding guide `LLM_STARTUP.md` → `CLAUDE.md` so Claude Code auto-loads it as session context.

The document content is otherwise unchanged (git detects it as a pure rename). All references are updated so no links break:
- `docs/ARCHITECTURE.md` (file tree + onboarding link)
- `docs/REQUIREMENTS.md` (related-docs link)
- `docs/adr/001-strict-ip-identity.md` (references section)
- `docs/adr/003-low-interference-sentinel-reconciliation.md` (Section 2.5 citation)
- the guide's own self-reference in the Documentation Maintenance rule

The H1 title remains "LittleRed - LLM Startup Guide" — the guide stays LLM-agnostic in content; only the filename adopts the Claude Code convention.

## Test plan
- `grep -rn LLM_STARTUP` over the repo returns no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)