### PR TITLE
feat: add release preparation script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,23 +112,47 @@ jobs:
           done
           GOOS=windows GOARCH=amd64 go build -o dist/lrctl-windows-amd64.exe ./cmd/lrctl/main.go
 
+      - name: Build release notes
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          # Print the body of the CHANGELOG.md section whose heading starts with
+          # the literal prefix $1, stopping at the next "## " heading.
+          extract() {
+            awk -v prefix="$1" '
+              index($0, prefix) == 1 { capture = 1; next }
+              capture && /^## / { exit }
+              capture { print }
+            ' CHANGELOG.md
+          }
+          # Prefer the section for the exact released version, fall back to [Unreleased].
+          notes="$(extract "## [${version}]")"
+          printf '%s' "$notes" | grep -q '[^[:space:]]' || notes="$(extract '## [Unreleased]')"
+          : > release-notes.md
+          if printf '%s' "$notes" | grep -q '[^[:space:]]'; then
+            printf "## What's Changed\n%s\n\n" "$notes" >> release-notes.md
+          fi
+          cat >> release-notes.md <<'EOF'
+          ## Container Images
+
+          ```
+          ghcr.io/${{ github.repository_owner }}/littlered:${{ github.ref_name }}
+          ghcr.io/${{ github.repository_owner }}/littlered-chaos-client:${{ github.ref_name }}
+          ```
+
+          ## Helm Chart
+
+          ```
+          helm install littlered oci://ghcr.io/${{ github.repository_owner }}/charts/littlered --version ${{ github.ref_name }}
+          ```
+          EOF
+          echo "----- generated release notes -----"
+          cat release-notes.md
+
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
           files: dist/*
-          body: |
-            ## Container Images
-
-            ```
-            ghcr.io/${{ github.repository_owner }}/littlered:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/littlered-chaos-client:${{ github.ref_name }}
-            ```
-
-            ## Helm Chart
-
-            ```
-            helm install littlered oci://ghcr.io/${{ github.repository_owner }}/charts/littlered --version ${{ github.ref_name }}
-            ```
+          body_path: release-notes.md
 
   chart:
     name: Push Helm chart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Record changes under `[Unreleased]`; see [RELEASING.md](RELEASING.md) for how to
+cut a release (`scripts/prepare-release.sh`).
+
+## [Unreleased]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,52 @@
+# Releasing
+
+Releases are published by [`.github/workflows/publish.yml`](.github/workflows/publish.yml),
+which triggers on pushing a `v*` git tag. The workflow builds and pushes the
+container images and Helm chart, builds the `lrctl` binaries, and creates a
+GitHub Release. The release notes are generated from the matching section of
+[`CHANGELOG.md`](CHANGELOG.md) (falling back to `[Unreleased]` if no
+version-specific section exists).
+
+## Keeping the changelog
+
+Record user-facing changes under the `## [Unreleased]` section of
+`CHANGELOG.md` as they are merged, grouped under `Added` / `Changed` /
+`Deprecated` / `Removed` / `Fixed` / `Security`
+([Keep a Changelog](https://keepachangelog.com/en/1.1.0/)).
+
+## Cutting a release
+
+Use the helper script to promote `[Unreleased]` to the new version, bump the
+Helm chart version to match (required — `publish.yml` fails the release if the
+tag and `charts/littlered/Chart.yaml` version differ), and optionally commit and
+tag:
+
+```bash
+# Edit CHANGELOG.md / Chart.yaml only, then print the git commands to run:
+scripts/prepare-release.sh 0.3.0
+
+# Or have the script commit and create the tag in one step:
+scripts/prepare-release.sh 0.3.0 --tag
+```
+
+Then push to trigger the publish workflow:
+
+```bash
+git push origin main --follow-tags
+```
+
+The script never pushes — pushing the tag is what kicks off the release, so it
+is left as an explicit, deliberate step.
+
+### What the script does
+
+- Promotes `## [Unreleased]` to `## [<version>] - <YYYY-MM-DD>` and leaves a
+  fresh empty `## [Unreleased]` on top.
+- Sets `version:` in `charts/littlered/Chart.yaml` to `<version>`.
+- Refuses to run if the `[Unreleased]` section is empty (override with
+  `--allow-empty`), if a section for the version already exists, or if the
+  version is not valid semver.
+- With `--commit` it commits both files; with `--tag` it also creates the
+  annotated `v<version>` tag (implies `--commit`).
+
+Run `scripts/prepare-release.sh --help` for the full flag list.

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# prepare-release.sh — prepare a release locally.
+#
+# Rolls CHANGELOG.md (promotes the [Unreleased] section to the new version) and
+# bumps charts/littlered/Chart.yaml to match, so that the version embedded in the
+# git tag matches Chart.yaml (required by .github/workflows/publish.yml) and the
+# generated GitHub release notes pick up a version-specific changelog section.
+#
+# Usage:
+#   scripts/prepare-release.sh <version> [--commit] [--tag] [--allow-empty]
+#
+#   <version>       Release version, with or without a leading 'v' (e.g. 0.3.0 or v0.3.0).
+#   --commit        git add + commit the CHANGELOG.md and Chart.yaml changes.
+#   --tag           Create an annotated git tag v<version> (implies --commit).
+#   --allow-empty   Proceed even if the [Unreleased] section has no entries.
+#
+# The script never pushes. After running with --tag, publish the release with:
+#   git push origin main --follow-tags
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHANGELOG="${REPO_ROOT}/CHANGELOG.md"
+CHART="${REPO_ROOT}/charts/littlered/Chart.yaml"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+VERSION=""
+DO_COMMIT=0
+DO_TAG=0
+ALLOW_EMPTY=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --commit) DO_COMMIT=1 ;;
+    --tag) DO_TAG=1; DO_COMMIT=1 ;;
+    --allow-empty) ALLOW_EMPTY=1 ;;
+    -h|--help) sed -n '2,21p' "$0"; exit 0 ;;
+    -*) die "unknown flag: $arg" ;;
+    *)
+      [ -z "$VERSION" ] || die "unexpected extra argument: $arg"
+      VERSION="$arg"
+      ;;
+  esac
+done
+
+[ -n "$VERSION" ] || die "missing <version> argument (e.g. 0.3.0)"
+
+# Normalise: strip a leading 'v', then validate strict X.Y.Z (with optional -prerelease).
+VERSION="${VERSION#v}"
+echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' \
+  || die "version '$VERSION' is not valid semver (expected X.Y.Z[-prerelease])"
+
+[ -f "$CHANGELOG" ] || die "$CHANGELOG not found"
+[ -f "$CHART" ] || die "$CHART not found"
+
+grep -qE '^## \[Unreleased\]' "$CHANGELOG" || die "no '## [Unreleased]' section in CHANGELOG.md"
+if grep -qE "^## \[${VERSION//./\\.}\]" "$CHANGELOG"; then
+  die "CHANGELOG.md already has a section for ${VERSION}"
+fi
+
+# Body of the [Unreleased] section, used to guard against an empty release.
+UNRELEASED_BODY="$(awk '
+  index($0, "## [Unreleased]") == 1 { capture = 1; next }
+  capture && /^## / { exit }
+  capture { print }
+' "$CHANGELOG")"
+if ! printf '%s' "$UNRELEASED_BODY" | grep -q '[^[:space:]]'; then
+  if [ "$ALLOW_EMPTY" -eq 0 ]; then
+    die "the [Unreleased] section is empty; add entries or pass --allow-empty"
+  fi
+  echo "WARNING: releasing with an empty [Unreleased] section" >&2
+fi
+
+RELEASE_DATE="$(date -u +%Y-%m-%d)"
+
+# Roll the changelog: keep an empty [Unreleased] at the top, insert the new
+# version heading immediately below it.
+awk -v ver="$VERSION" -v date="$RELEASE_DATE" '
+  !done && $0 == "## [Unreleased]" {
+    print
+    print ""
+    print "## [" ver "] - " date
+    done = 1
+    next
+  }
+  { print }
+' "$CHANGELOG" > "${CHANGELOG}.tmp"
+mv "${CHANGELOG}.tmp" "$CHANGELOG"
+
+# Bump the chart version (publish.yml fails the release if it does not match the tag).
+awk -v ver="$VERSION" '
+  /^version:/ && !done { print "version: " ver; done = 1; next }
+  { print }
+' "$CHART" > "${CHART}.tmp"
+mv "${CHART}.tmp" "$CHART"
+
+echo "Prepared release v${VERSION} (${RELEASE_DATE}):"
+echo "  - CHANGELOG.md: promoted [Unreleased] -> [${VERSION}]"
+echo "  - charts/littlered/Chart.yaml: version -> ${VERSION}"
+
+if [ "$DO_COMMIT" -eq 1 ]; then
+  git -C "$REPO_ROOT" add CHANGELOG.md charts/littlered/Chart.yaml
+  git -C "$REPO_ROOT" commit -m "Release v${VERSION}"
+  echo "  - committed"
+fi
+
+if [ "$DO_TAG" -eq 1 ]; then
+  git -C "$REPO_ROOT" tag -a "v${VERSION}" -m "Release v${VERSION}"
+  echo "  - tagged v${VERSION}"
+fi
+
+echo
+echo "Next steps:"
+if [ "$DO_COMMIT" -eq 0 ]; then
+  echo "  git add CHANGELOG.md charts/littlered/Chart.yaml && git commit -m 'Release v${VERSION}'"
+fi
+if [ "$DO_TAG" -eq 0 ]; then
+  echo "  git tag -a v${VERSION} -m 'Release v${VERSION}'"
+fi
+echo "  git push origin main --follow-tags   # triggers .github/workflows/publish.yml"


### PR DESCRIPTION
Add scripts/prepare-release.sh to promote [Unreleased] to a versioned section and bump the Helm chart version, RELEASING.md documenting the release process, and a CHANGELOG.md scaffold. publish.yml now generates GitHub Release notes from the matching CHANGELOG section (body_path) instead of a hardcoded body.