### PR TITLE
fix(chart): suppress the operator's own PDB for a single-replica deployment

### DIFF
--- a/charts/littlered/templates/poddisruptionbudget.yaml
+++ b/charts/littlered/templates/poddisruptionbudget.yaml
@@ -1,4 +1,11 @@
-{{- if .Values.podDisruptionBudget.create }}
+{{- /*
+A PodDisruptionBudget over a single-pod workload is counter-productive: it can only
+ever block node drains, never protect availability. The operator Deployment runs a
+single replica by default, so its own PDB is only rendered when running with
+redundancy (replicas > 1). This mirrors the rule the operator applies to the
+managed Redis instances it creates (spec.podDisruptionBudget).
+*/}}
+{{- if and .Values.podDisruptionBudget.create (gt (int .Values.replicas) 1) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/littlered/values.yaml
+++ b/charts/littlered/values.yaml
@@ -44,9 +44,13 @@ networkPolicy:
   enabled: false
 
 podDisruptionBudget:
-  # Creates a PodDisruptionBudget for the operator deployment itself.
-  # PDBs for managed LittleRed instances are controlled per-CR via
-  # spec.podDisruptionBudget (created by default; set create: false to opt out).
+  # Controls the PodDisruptionBudget for the OPERATOR Deployment itself only.
+  # PDBs for managed LittleRed instances are a separate concern, controlled per-CR
+  # via spec.podDisruptionBudget (created by default; set create: false to opt out).
+  #
+  # A PDB is only rendered when create is true AND replicas > 1: over a single
+  # operator pod a PDB is counter-productive (it can only block node drains, never
+  # protect availability), so it is suppressed regardless of create.
   create: false
   # Set one of maxUnavailable / minAvailable (mutually exclusive).
   # minAvailable takes precedence when set.


### PR DESCRIPTION
## What

Renders the operator Deployment's own PodDisruptionBudget (Helm chart) **only when `create: true` AND `replicas > 1`**. With the default single replica it is suppressed regardless of `create`.

## Why

A PDB over a single-pod workload is counter-productive — it can only ever block node drains, never protect availability. This is the same rule the operator now applies to the managed Redis instances it creates (#92, per Michael's review). Applying it to the operator's *own* PDB keeps the two concerns consistent and addresses the "operator-own PDB vs. instance PDBs" conflation: the top-level `podDisruptionBudget` values block governs the operator Deployment only; instance PDBs are configured per-CR via `spec.podDisruptionBudget`.

## Behaviour

| `create` | `replicas` | operator PDB |
|----------|-----------|--------------|
| `false` (default) | any | none |
| `true` | `1` (default) | none (single-pod rule) |
| `true` | `> 1` | rendered (`maxUnavailable: 1`, or `minAvailable` if set) |

## Verification

- `helm template` across all four cases above — correct.
- `helm lint` — 0 failures.

## Notes

- Stacked on `pdb-default-on` (#92); retarget to `main` once #92 merges.
- Default `create` left at `false`; not flipped to default-on. Open to flipping it (mirroring the instance default-on) if preferred — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)