### PR TITLE
fix(chart): repair the orphan {{- end }} that broke every install since 0.2.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,18 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
+
+  chart:
+    name: Helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v7
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      # A template-syntax error in the chart is invisible to the Go linter and
+      # only surfaces at `helm install` time on the user's cluster.
+      - name: Lint and render the chart
+        run: make helm-lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,6 +171,11 @@ jobs:
             exit 1
           fi
 
+      # Never push a chart that does not parse: a template-syntax error only
+      # surfaces at `helm install` time, i.e. on the user's cluster.
+      - name: Lint and render the chart
+        run: make helm-lint
+
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ cut a release (`scripts/prepare-release.sh`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Helm chart did not parse** — `helm install`/`helm upgrade` failed with
+  `parse error at (littlered/templates/rolebinding.yaml:16): unexpected {{end}}`
+  for **every** chart version from 0.2.2 on. Making leader election
+  non-configurable removed the `{{- if .Values.leaderElection.enabled }}` guard
+  from `role.yaml` and `rolebinding.yaml`, but the namespace-scoping change
+  (ADR-014) was integrated with the guard's closing `{{- end }}` left behind in
+  both files, closing nothing. `values.yaml` likewise carried a duplicated
+  `scope:` block. Charts 0.2.2 and 0.3.0 have been republished with the fix.
+- **CI now lints and renders the chart** (`make helm-lint`, run on every push and
+  again before the release job pushes to the registry) in the default,
+  allow-list and deny-list scoping modes. A chart template error is invisible to
+  the Go linter and previously only surfaced on the user's cluster.
+
 ## [0.3.0] - 2026-08-11
 
 Everything below has landed since `v0.2.2`. The headline is a restructure of

--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,20 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 lint-config: golangci-lint ## Verify golangci-lint linter configuration
 	"$(GOLANGCI_LINT)" config verify
 
+.PHONY: helm-lint
+helm-lint: ## Lint the Helm chart and render it in every scoping mode.
+	$(HELM) lint charts/littlered
+	$(HELM) template littlered charts/littlered > /dev/null
+	$(HELM) template littlered charts/littlered \
+		--set 'scope.watchNamespaces={ns-a,ns-b}' > /dev/null
+	$(HELM) template littlered charts/littlered \
+		--set 'scope.ignoreNamespaces={kube-system}' > /dev/null
+	$(HELM) template littlered charts/littlered \
+		--set metrics.enabled=true \
+		--set metrics.serviceMonitor.enabled=true \
+		--set networkPolicy.enabled=true > /dev/null
+	@echo "Helm chart lints and renders in all scoping modes."
+
 ##@ Build
 
 .PHONY: build

--- a/charts/littlered/templates/role.yaml
+++ b/charts/littlered/templates/role.yaml
@@ -37,7 +37,6 @@ rules:
     verbs:
       - create
       - patch
-{{- end }}
 {{- /*
 Allow-list scoping (ADR-014): render a namespaced manager Role carrying the
 operator's reconcile rules in EACH watched namespace, in place of the

--- a/charts/littlered/templates/rolebinding.yaml
+++ b/charts/littlered/templates/rolebinding.yaml
@@ -13,7 +13,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "littlered.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end }}
 {{- /*
 Allow-list scoping (ADR-014): bind the per-namespace manager Role (role.yaml) to
 the operator's ServiceAccount (which lives in the operator's own namespace) in

--- a/charts/littlered/values.yaml
+++ b/charts/littlered/values.yaml
@@ -47,19 +47,6 @@ scope:
   # keeps the ClusterRole and sets IGNORE_NAMESPACE on the operator.
   ignoreNamespaces: []
 
-# Namespace scoping (ADR-014). By default the operator is cluster-scoped: it
-# watches every LittleRed CR in every namespace and ships cluster-wide RBAC
-# (ClusterRole + ClusterRoleBinding). Set AT MOST ONE of the two lists below.
-scope:
-  # Allow-list. Watch only these namespaces. Renders least-privilege NAMESPACED
-  # RBAC (a Role + RoleBinding in each listed namespace) instead of the
-  # ClusterRole, and sets WATCH_NAMESPACE on the operator. Mutually exclusive
-  # with ignoreNamespaces (setting both fails the render).
-  watchNamespaces: []
-  # Deny-list. Watch all namespaces EXCEPT these. Inherently cluster-wide, so it
-  # keeps the ClusterRole and sets IGNORE_NAMESPACE on the operator.
-  ignoreNamespaces: []
-
 metrics:
   # Enable the operator metrics endpoint (HTTP on the specified port).
   # When enabled, a Service is created and --metrics-bind-address is set on the manager.


### PR DESCRIPTION
`helm install`/`helm upgrade` fails on **every published chart from 0.2.2 on**:

```
Error: parse error at (littlered/templates/rolebinding.yaml:16): unexpected {{end}}
```

## Cause

Removing the leader-election toggle deleted both halves of the
`{{- if .Values.leaderElection.enabled }}` guard from `role.yaml` and
`rolebinding.yaml`. The namespace-scoping change (ADR-014) appended its scoping
block after that guard, and integrating the two brought the closing `{{- end }}`
back as *new content* on a base that no longer had the opening `if` — an orphan
that closes nothing, so the chart never parsed. `values.yaml` picked up a
duplicated `scope:` block from the same resolution (harmless only because Helm's
last-wins hid it).

Leader election is unconditionally on in the manager, so the leader-election
Role/RoleBinding are unconditionally rendered: dropping the stray `{{- end }}` is
the whole fix — no guard is reinstated.

## Guard

`make helm-lint` lints the chart and renders it in the default, allow-list and
deny-list scoping modes (plus metrics/ServiceMonitor/NetworkPolicy on). Wired
into the Lint workflow on every push, and into the release job *before* it pushes
to the registry. A chart template error is invisible to golangci-lint and
otherwise only surfaces on the user's cluster.

Verified red first: run against the published chart tree, the guard reproduces
the exact parse error above; green after the fix.

## Registry

Charts `0.2.2` and `0.3.0` are being republished with the same fix so existing
`--version` pins stop failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)